### PR TITLE
XSS patch

### DIFF
--- a/shortcode.php
+++ b/shortcode.php
@@ -45,8 +45,8 @@ function gallery_embed($atts) {
     ?>
         <script>
             window.onload = function () {
-                galleryApp.imageUrls = JSON.parse('<?php echo json_encode( $image_urls ) ?>');
-                galleryApp.items = JSON.parse('<?php echo json_encode( $gallery->items ); ?>');
+                galleryApp.imageUrls = <?php echo json_encode( $image_urls ) ?>;
+                galleryApp.items = <?php echo json_encode( $gallery->items ); ?>;
             };
         </script>
     <?php


### PR DESCRIPTION
A site admin could use a single quote to end the JSON parsed string. Either accidentally breaking the plugin, or used maliciously.